### PR TITLE
feat: Add dataset organizer for train/test/eval splits (#81)

### DIFF
--- a/Partiticipants/23150020039/23150020039.ipynb
+++ b/Partiticipants/23150020039/23150020039.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dataset Organization: Train / Test / Eval Splits\n",
+    "\n",
+    "This notebook provides reusable functions to organize class-separated image datasets into standard train/test/eval directory splits for reproducible training and evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_directory_structure(dest_dir, classes):\n",
+    "    \"\"\"\n",
+    "    Create the dataset directory structure.\n",
+    "    \n",
+    "    Args:\n",
+    "        dest_dir: Destination directory path\n",
+    "        classes: List of class names\n",
+    "    \"\"\"\n",
+    "    splits = ['train', 'test', 'eval']\n",
+    "    for split in splits:\n",
+    "        for cls in classes:\n",
+    "            os.makedirs(os.path.join(dest_dir, split, cls), exist_ok=True)\n",
+    "    print(f\"Created directory structure in '{dest_dir}/'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_files(files, train_ratio=0.7, test_ratio=0.15, eval_ratio=0.15, seed=42):\n",
+    "    \"\"\"\n",
+    "    Split file list into train, test, and eval sets.\n",
+    "    \n",
+    "    Args:\n",
+    "        files: List of file names\n",
+    "        train_ratio: Proportion for training (default 0.7)\n",
+    "        test_ratio: Proportion for testing (default 0.15)\n",
+    "        eval_ratio: Proportion for evaluation (default 0.15)\n",
+    "        seed: Random seed for reproducibility\n",
+    "    \n",
+    "    Returns:\n",
+    "        Tuple of (train_files, test_files, eval_files)\n",
+    "    \"\"\"\n",
+    "    assert abs(train_ratio + test_ratio + eval_ratio - 1.0) < 1e-6, \"Ratios must sum to 1\"\n",
+    "    \n",
+    "    train_files, temp_files = train_test_split(files, train_size=train_ratio, random_state=seed)\n",
+    "    relative_test = test_ratio / (test_ratio + eval_ratio)\n",
+    "    test_files, eval_files = train_test_split(temp_files, train_size=relative_test, random_state=seed)\n",
+    "    \n",
+    "    return train_files, test_files, eval_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def copy_files_to_split(files, source_cls_path, dest_dir, split, cls):\n",
+    "    \"\"\"\n",
+    "    Copy files to the appropriate split directory.\n",
+    "    \n",
+    "    Args:\n",
+    "        files: List of file names to copy\n",
+    "        source_cls_path: Source class directory path\n",
+    "        dest_dir: Destination base directory\n",
+    "        split: Split name ('train', 'test', or 'eval')\n",
+    "        cls: Class name\n",
+    "    \"\"\"\n",
+    "    for f in files:\n",
+    "        src = os.path.join(source_cls_path, f)\n",
+    "        dst = os.path.join(dest_dir, split, cls, f)\n",
+    "        shutil.copy2(src, dst)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def organize_dataset(source_dir, dest_dir='dataset', train_ratio=0.7, test_ratio=0.15, eval_ratio=0.15, seed=42):\n",
+    "    \"\"\"\n",
+    "    Organize class-separated images into train/test/eval splits.\n",
+    "    \n",
+    "    Args:\n",
+    "        source_dir: Path to source directory containing class folders\n",
+    "        dest_dir: Path to destination dataset directory (default 'dataset')\n",
+    "        train_ratio: Proportion for training set (default 0.7)\n",
+    "        test_ratio: Proportion for test set (default 0.15)\n",
+    "        eval_ratio: Proportion for eval set (default 0.15)\n",
+    "        seed: Random seed for reproducibility (default 42)\n",
+    "    \n",
+    "    Returns:\n",
+    "        Path to the organized dataset directory\n",
+    "    \"\"\"\n",
+    "    # Get class directories\n",
+    "    classes = [d for d in os.listdir(source_dir) if os.path.isdir(os.path.join(source_dir, d))]\n",
+    "    \n",
+    "    if not classes:\n",
+    "        raise ValueError(f\"No class directories found in '{source_dir}'\")\n",
+    "    \n",
+    "    # Create directory structure\n",
+    "    create_directory_structure(dest_dir, classes)\n",
+    "    \n",
+    "    # Process each class\n",
+    "    stats = {'train': 0, 'test': 0, 'eval': 0}\n",
+    "    \n",
+    "    for cls in classes:\n",
+    "        cls_path = os.path.join(source_dir, cls)\n",
+    "        files = [f for f in os.listdir(cls_path) if os.path.isfile(os.path.join(cls_path, f))]\n",
+    "        \n",
+    "        if not files:\n",
+    "            print(f\"Warning: No files found in class '{cls}'\")\n",
+    "            continue\n",
+    "        \n",
+    "        # Split files\n",
+    "        train_files, test_files, eval_files = split_files(\n",
+    "            files, train_ratio, test_ratio, eval_ratio, seed\n",
+    "        )\n",
+    "        \n",
+    "        # Copy to respective directories\n",
+    "        copy_files_to_split(train_files, cls_path, dest_dir, 'train', cls)\n",
+    "        copy_files_to_split(test_files, cls_path, dest_dir, 'test', cls)\n",
+    "        copy_files_to_split(eval_files, cls_path, dest_dir, 'eval', cls)\n",
+    "        \n",
+    "        stats['train'] += len(train_files)\n",
+    "        stats['test'] += len(test_files)\n",
+    "        stats['eval'] += len(eval_files)\n",
+    "    \n",
+    "    print(f\"\\nDataset organized successfully!\")\n",
+    "    print(f\"Classes: {len(classes)}\")\n",
+    "    print(f\"Train: {stats['train']} files\")\n",
+    "    print(f\"Test: {stats['test']} files\")\n",
+    "    print(f\"Eval: {stats['eval']} files\")\n",
+    "    \n",
+    "    return dest_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage Example\n",
+    "\n",
+    "```python\n",
+    "# Organize dataset with default 70/15/15 split\n",
+    "organize_dataset('path/to/source/images')\n",
+    "\n",
+    "# Custom split ratios\n",
+    "organize_dataset('path/to/source/images', dest_dir='my_dataset', \n",
+    "                 train_ratio=0.8, test_ratio=0.1, eval_ratio=0.1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and modify the path to run\n",
+    "# organize_dataset('path/to/your/source/images')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Issue: #81

Added notebook with reusable functions to organize class-separated image datasets into train/test/eval directory splits.

- `organize_dataset()` - Main function to split and organize images
- Configurable split ratios (default 70/15/15)
- Reproducible splits with random seed
